### PR TITLE
[ENH] Add CI (travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,22 @@
+# the type of machine to run tests
 dist: xenial
 sudo: true
 language: python
 
+# which versions of python to test
 python:
   - 3.5
   - 3.6
   - 3.7
 
+# somewhat arbitrary to install dependencies beforehand
 before_install:
   - pip install pytest
 
+# install the nii-masker package
 install:
   - pip install .
 
+# run pytest
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+dist: xenial
+sudo: true
+language: python
+
+python:
+  - 3.5
+  - 3.6
+  - 3.7
+
+before_install:
+  - pip install pytest
+
+install:
+  - pip install .
+
+script:
+  - pytest

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@ setup(
         'pandas',
         'nibabel',
         'nilearn>=0.5.0',
-        'natsort'
+        'natsort',
+        'scipy',
+        'scikit-learn'
     ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
no frills pytest running on python 3.5, 3.6, and 3.7.

I also added a couple missing dependencies (`scipy` and `scikit-learn`).

build is [passing on my account](https://travis-ci.org/jdkent/nii-masker/builds/542370948)

make a [travisci account](https://docs.travis-ci.com/user/tutorial/) and I think you should be in business.