### PR TITLE
[ENH] Fetch atlases directly using nilearn functions

### DIFF
--- a/niimasker/atlases.py
+++ b/niimasker/atlases.py
@@ -6,8 +6,35 @@ from nilearn.datasets import (fetch_atlas_destrieux_2009, fetch_atlas_yeo_2011,
                               fetch_atlas_talairach, fetch_atlas_schaefer_2018)
 
 
-def _get_atlas_function(query, data_dir=None):
-    """Fetch atlas based on atlas input string"""
+def get_labelled_atlas(query, data_dir=None, return_labels=True):
+    """Parses input query to determine which atlas to fetch and what version
+    of the atlas to use (if applicable).
+
+    Parameters
+    ----------
+    query : str
+        Input string in the following format:
+        nilearn:{atlas_name}:{atlas_parameters}. The following can be for
+        `atlas_name`: 'destrieux', 'yeo', 'aal', 'talairach', and 'schaefer'.
+        `atlas_parameters` is not available for the `destrieux` atlas.
+    data_dir : str, optional
+        Directory in which to save atlas data. By default None, which creates
+        a ~/nilearn_data/ directory as per nilearn.
+    return_labels : bool, optional
+        Whether to return atlas labels. Default is True. Not available for the
+        'basc' atlas.
+
+    Returns
+    -------
+    str, list or None
+        The atlas image and the accompanying labels (if provided)
+
+    Raises
+    ------
+    ValueError
+        Raised when the query does is not formatted correctly or if the no
+        match found.
+    """
 
     # extract parameters
     params = query.split(':')
@@ -55,5 +82,8 @@ def _get_atlas_function(query, data_dir=None):
         labels = atlas['labels']
     else:
         raise ValueError('No atlas detected. Check query string')
+
+    if not return_labels:
+        labels = None
 
     return img, labels

--- a/niimasker/atlases.py
+++ b/niimasker/atlases.py
@@ -87,3 +87,7 @@ def get_labelled_atlas(query, data_dir=None, return_labels=True):
         labels = None
 
     return img, labels
+
+
+def get_prob_atlas(query, data_dir=None, return_labels=True):
+    pass

--- a/niimasker/atlases.py
+++ b/niimasker/atlases.py
@@ -1,0 +1,52 @@
+"""Module that maps input strings to nilearn's atlas functions"""
+
+import pandas as pd
+from nilearn.datasets import (fetch_atlas_destrieux_2009, fetch_atlas_yeo_2011,
+                              fetch_atlas_aal, fetch_atlas_basc_multiscale_2015,
+                              fetch_atlas_talairach, fetch_atlas_schaefer_2018)
+
+
+def _get_atlas_function(query, data_dir=None):
+    """Fetch atlas based on atlas input string"""
+
+    # extract parameters
+    params = query.split(':')
+    if len(params) == 3:
+        _, atlas_name, sub_param = params
+    elif len(params) == 2:
+        _, atlas_name = params
+        sub_param = None
+    else:
+        raise ValueError('Incorrect atlas query string provided')
+
+    # get atlas
+    if atlas_name == 'destrieux':
+        atlas = fetch_atlas_destrieux_2009(lateralized=True, data_dir=data_dir)
+        img = atlas['maps']
+        labels = atlas['labels']
+    elif atlas_name == 'yeo':
+        atlas = fetch_atlas_yeo_2011(data_dir=data_dir)
+        img = atlas[sub_param]
+        if '17' in sub_param:
+            labels = pd.read_csv(atlas['colors_17'], sep='\s+')['NONE'].tolist()
+    elif atlas_name == 'aal':
+        version = 'SPM12' if sub_param is None else sub_param
+        atlas = fetch_atlas_aal(version=version, data_dir=data_dir)
+        img = atlas['maps']
+        labels = atlas['labels']
+    elif atlas_name == 'talairach':
+        atlas = fetch_atlas_talairach(level_name=sub_param, data_dir=data_dir)
+        img = atlas['maps']
+        labels = atlas['labels']
+    elif atlas_name == 'schaefer':
+        n_rois, networks, resolution = sub_param.split('-')
+        atlas = fetch_atlas_schaefer_2018(n_rois=int(n_rois),
+                                          yeo_networks=int(networks),
+                                          resolution_mm=int(resolution),
+                                          data_dir=data_dir)
+        img = atlas['maps']
+        labels = atlas['labels']
+    else:
+        raise ValueError('No atlas detected. Check query string')
+
+    return img, labels

--- a/niimasker/atlases.py
+++ b/niimasker/atlases.py
@@ -55,7 +55,7 @@ def get_labelled_atlas(query, data_dir=None, return_labels=True):
         atlas = fetch_atlas_yeo_2011(data_dir=data_dir)
         img = atlas[sub_param]
         if '17' in sub_param:
-            labels = pd.read_csv(atlas['colors_17'], sep='\s+')['NONE'].tolist()
+            labels = pd.read_csv(atlas['colors_17'], sep=r'\s+')['NONE'].tolist()
     elif atlas_name == 'aal':
         version = 'SPM12' if sub_param is None else sub_param
         atlas = fetch_atlas_aal(version=version, data_dir=data_dir)

--- a/niimasker/atlases.py
+++ b/niimasker/atlases.py
@@ -34,6 +34,13 @@ def _get_atlas_function(query, data_dir=None):
         atlas = fetch_atlas_aal(version=version, data_dir=data_dir)
         img = atlas['maps']
         labels = atlas['labels']
+    elif atlas_name == 'basc':
+
+        version, scale = sub_param.split('-')
+        atlas = fetch_atlas_basc_multiscale_2015(version=version,
+                                                 data_dir=data_dir)
+        img = atlas['scale{}'.format(scale.zfill(3))]
+        labels = None
     elif atlas_name == 'talairach':
         atlas = fetch_atlas_talairach(level_name=sub_param, data_dir=data_dir)
         img = atlas['maps']

--- a/niimasker/niimasker.py
+++ b/niimasker/niimasker.py
@@ -127,7 +127,7 @@ def make_timeseries(input_files, mask_img, output_dir, labels=None,
     ----------
     input_files : list of niimg-like
         List of input NIfTI functional images
-    roi_file : niimg-like
+    mask_img : niimg-like
         Image that contains region mask(s). Can either be a single binary mask
         for a single region, or a numerically labeled atlas file. 0 must
         indicate background (non-region voxels).

--- a/niimasker/niimasker.py
+++ b/niimasker/niimasker.py
@@ -127,7 +127,7 @@ def make_timeseries(input_files, mask_img, output_dir, labels=None,
     ----------
     input_files : list of niimg-like
         List of input NIfTI functional images
-    mask_img : niimg-like
+    mask_img : str
         Image that contains region mask(s). Can either be a single binary mask
         for a single region, or a numerically labeled atlas file. 0 must
         indicate background (non-region voxels).


### PR DESCRIPTION
Refers to #1. Provides a query syntax to tell nilearn to fetch various atlases using its `fetch_atlas*` functions. CLI checked locally until tests written for CLI functions